### PR TITLE
Exchange info parsing error fix

### DIFF
--- a/src/main/scala/com/binance/api/client/domain/account/Account.scala
+++ b/src/main/scala/com/binance/api/client/domain/account/Account.scala
@@ -1,6 +1,6 @@
 package com.binance.api.client.domain.account
 
-import com.binance.api.client.domain.{Asset, AssetBalanceFull, Instant}
+import com.binance.api.client.domain.{Asset, AssetBalance, Instant}
 
 /**
   * Account information.
@@ -41,7 +41,7 @@ case class Account(
     /**
       * List of asset balances of this account.
       */
-    balances: List[AssetBalanceFull]
+    balances: List[AssetBalance]
 ) {
 
   /**
@@ -50,6 +50,6 @@ case class Account(
     * @param symbol asset symbol to obtain the balances from
     * @return an asset balance for the given symbol which can be 0 in case the symbol has no balance in the account
     */
-  def getAssetBalance(symbol: Asset): Option[AssetBalanceFull] =
+  def getAssetBalance(symbol: Asset): Option[AssetBalance] =
     balances.find(_.asset == symbol)
 }

--- a/src/main/scala/com/binance/api/client/domain/general/ExchangeInfo.scala
+++ b/src/main/scala/com/binance/api/client/domain/general/ExchangeInfo.scala
@@ -10,7 +10,8 @@ case class ExchangeInfo(
     timezone:   String,
     serverTime: Instant,
     rateLimits: List[RateLimit],
-    symbols:    List[SymbolInfo]
+    symbols:    List[SymbolInfo],
+    exchangeFilters: List[ExchangeFilter]
 ) {
   lazy val getSymbolInfo: Map[Symbol, SymbolInfo] =
     symbols.map(s => s.symbol -> s)(collection.breakOut)

--- a/src/main/scala/com/binance/api/client/domain/general/FilterType.java
+++ b/src/main/scala/com/binance/api/client/domain/general/FilterType.java
@@ -11,6 +11,7 @@ public enum FilterType {
   MAX_NUM_ORDERS,
   MAX_ALGO_ORDERS,
   MAX_NUM_ALGO_ORDERS,
+  ICEBERG_PARTS,
 
   // Exchange
   EXCHANGE_MAX_NUM_ORDERS,

--- a/src/main/scala/com/binance/api/client/domain/general/SymbolFilter.scala
+++ b/src/main/scala/com/binance/api/client/domain/general/SymbolFilter.scala
@@ -49,5 +49,5 @@ case class SymbolFilter(
       * MAX_NUM_ORDERS filter defines the maximum number of orders an account is allowed to have open on a symbol. Note that both "algo" orders and normal orders are counted for this filter.
       * MAX_ALGO_ORDERS filter defines the maximum number of "algo" orders an account is allowed to have open on a symbol. "Algo" orders are STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.
       */
-    limit: Option[String]
+    limit: Option[Int]
 )

--- a/src/test/java/com/binance/api/domain/general/ExchangeInfoDeserializerTest.scala
+++ b/src/test/java/com/binance/api/domain/general/ExchangeInfoDeserializerTest.scala
@@ -54,6 +54,9 @@ class ExchangeInfoDeserializerTest {
     }, {
       "filterType": "MIN_NOTIONAL",
       "minNotional": "0.00100000"
+    }, {
+      "filterType": "ICEBERG_PARTS",
+      "limit": 10
     }]
   }]}"""
     assertEquals(
@@ -66,6 +69,7 @@ class ExchangeInfoDeserializerTest {
             RateLimit(rateLimitType = RateLimitType.ORDERS, interval = RateLimitInterval.SECOND, limit = 10),
             RateLimit(rateLimitType = RateLimitType.ORDERS, interval = RateLimitInterval.DAY, limit = 100000)
           ),
+          exchangeFilters = List.empty,
           symbols = List(
             SymbolInfo(
               symbol = Symbol("ETHBTC"),
@@ -109,6 +113,17 @@ class ExchangeInfoDeserializerTest {
                   stepSize = None,
                   minNotional = Some("0.00100000"),
                   limit = None
+                ),
+                SymbolFilter(
+                  filterType = FilterType.ICEBERG_PARTS,
+                  minPrice = None,
+                  maxPrice = None,
+                  tickSize = None,
+                  minQty = None,
+                  maxQty = None,
+                  stepSize = None,
+                  minNotional = None,
+                  limit = Some(10)
                 )
               )
             )


### PR DESCRIPTION
Fixed the FilterType limit field type: String -> Int
Added ICEBERG_PARTS to FilterType enum and updated the test
Added exchangeFilters field to ExchangeInfo and updated the test
Also replaced the usage of AssetBalanceFull with AssetBalance. There was a type error there, not sure why it was used instead of AssetBalance that's used everywhere else.

Cheers and thanks for the great work!